### PR TITLE
Baseline mod header utilizing Spriggit

### DIFF
--- a/.spriggit
+++ b/.spriggit
@@ -1,0 +1,5 @@
+{
+  "PackageName": "Spriggit.Yaml",
+  "Release": "Starfield",
+  "Version": "0.4"
+}

--- a/src/RecordData.yaml
+++ b/src/RecordData.yaml
@@ -1,0 +1,19 @@
+SpriggitSource:
+  PackageName: Spriggit.Yaml.Starfield
+  Version: 0.4
+ModKey: Starfield Community Patch.esm
+GameRelease: Starfield
+ModHeader:
+  Flags:
+  - Master
+  - Localized
+  Version: 2109106
+  FormVersion: 552
+  Stats:
+    Version: 0.96
+    NumRecords: 0
+    NextFormID: 2048
+  Author: Starfield Community
+  Description: Baseline bug fixes for Starfield
+  MasterReferences:
+  - Master: Starfield.esm

--- a/src/RecordData.yaml
+++ b/src/RecordData.yaml
@@ -1,7 +1,7 @@
 SpriggitSource:
   PackageName: Spriggit.Yaml.Starfield
   Version: 0.4
-ModKey: Starfield Community Patch.esm
+ModKey: StarfieldCommunityPatch.esm
 GameRelease: Starfield
 ModHeader:
   Flags:


### PR DESCRIPTION
- Added a `.spriggit` file to drive the community settings for serialization
- Added a minimal mod header to get things started:
  - Some values taken from OldMars.esm, such as Version and FormVersion
  - NextFormID set to 0x800, which is the Fallout4 default
  - Added a basic Author and Description

Let me know if any values should be tweaked based on the knowledge we have so far!   Also, we can probably discuss what we want the Author/Description to be a bit more, I'm sure.

Here's what the mod header has when converting from Spriggit to an actual file:
![image](https://github.com/Starfield-Community-Patch/Starfield-Community-Patch/assets/24981326/fd276a61-9402-4403-83f9-02b9de2562fd)