### PR TITLE
Add a workflow to publish nightly releases

### DIFF
--- a/.github/workflows/spriggit-out.yml
+++ b/.github/workflows/spriggit-out.yml
@@ -1,0 +1,54 @@
+name: spriggit-out
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+jobs:
+  publish:
+    permissions: write-all
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      
+      - name: Fetch spriggit
+        shell: bash
+        run: gh release download -O .github/spriggit.zip -p 'SpriggitLinuxCLI.zip' -R Mutagen-Modding/Spriggit ${{ inputs.spriggit_tool_version }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          
+      - name: Extract some files
+        shell: bash
+        run: 7z x .github/spriggit.zip -o.github/spriggit
+
+      - name: fix spriggit permission
+        shell: bash
+        run: chmod +x .github/spriggit/Spriggit.CLI
+
+      - name: run spriggit
+        shell: bash
+        run: .github/spriggit/Spriggit.CLI deserialize --InputPath "src/plugin" --OutputPath "${{ github.workspace }}/latest.esp" --PackageName Spriggit.Yaml.Skyrim
+
+      - name: Delete Existing Release
+        uses: dev-drprasad/delete-tag-and-release@v1.0
+        with:
+          tag_name: nightly
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          delete_release: true
+          
+      - name: Create Release
+        id: create_release
+        uses: ncipollo/release-action@v1.13.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          allowUpdates: true
+          name: Nightly
+          draft: false
+          body: Nightly release of the latest patch
+          tag: nightly
+          prerelease: true
+          makeLatest: true
+          removeArtifacts: true
+          replacesArtifacts: true
+          artifacts: ${{ github.workspace }}/latest.esp

--- a/.github/workflows/spriggit-out.yml
+++ b/.github/workflows/spriggit-out.yml
@@ -4,7 +4,21 @@ on:
     - cron: '0 9 * * *'
   workflow_dispatch:
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check for changes last 24 hours that modified src/plugin folder
+        id: should_run
+        shell: bash
+        run: echo "should_run=$(git log --since="1 days ago" --name-only | grep 'src/plugin/.*' -c)" >> "$GITHUB_OUTPUT"
+
   publish:
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.should_run == 1 }}
     permissions: write-all
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/spriggit-out.yml
+++ b/.github/workflows/spriggit-out.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: run spriggit
         shell: bash
-        run: .github/spriggit/Spriggit.CLI deserialize --InputPath "src/plugin" --OutputPath "${{ github.workspace }}/latest.esp" --PackageName Spriggit.Yaml.Skyrim
+        run: .github/spriggit/Spriggit.CLI deserialize --InputPath "src/plugin" --OutputPath "${{ github.workspace }}/StarfieldCommunityPatch.esm" --PackageName Spriggit.Yaml.Starfield
 
       - name: Delete Existing Release
         uses: dev-drprasad/delete-tag-and-release@v1.0
@@ -51,4 +51,4 @@ jobs:
           makeLatest: true
           removeArtifacts: true
           replacesArtifacts: true
-          artifacts: ${{ github.workspace }}/latest.esp
+          artifacts: ${{ github.workspace }}/StarfieldCommunityPatch.esm


### PR DESCRIPTION
Add a workflow to publish a nightly prerelease every day from the latest content

Tested on this repo:
https://github.com/Noggog/SpriggitWorkflowTests

I tried to get some short circuit logic where it wouldn't just blindly re-release every night, but I couldn't combine the schedule trigger /w paths filtering.   If someone figures that out, let me know!