### PR TITLE
Add GitLFS carveouts for expected asset files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+*.swf filter=lfs diff=lfs merge=lfs -text
+*.fla filter=lfs diff=lfs merge=lfs -text
+*.ai filter=lfs diff=lfs merge=lfs -text
+*.wav filter=lfs diff=lfs merge=lfs -text
+*.xwm filter=lfs diff=lfs merge=lfs -text
+*.fuz filter=lfs diff=lfs merge=lfs -text
+*.lip filter=lfs diff=lfs merge=lfs -text
+*.psd filter=lfs diff=lfs merge=lfs -text
+*.pdn filter=lfs diff=lfs merge=lfs -text
+*.nif filter=lfs diff=lfs merge=lfs -text
+*.max filter=lfs diff=lfs merge=lfs -text
+*.bgsm filter=lfs diff=lfs merge=lfs -text
+*.dds filter=lfs diff=lfs merge=lfs -text
+*.tga filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Files to be generated on publish
+*.esm
+*.esp
+*.esl
+*.pex


### PR DESCRIPTION
Prep for when we get asset files
- GitLFS for lots of assets
- .gitignore for esp + pex files, which we will generate on publishing