### PR TITLE
Fix SQ_ShipDebrisScript fails to shutdown quest

### DIFF
--- a/Scripts/Source/sq_shipdebrisscript.psc
+++ b/Scripts/Source/sq_shipdebrisscript.psc
@@ -7,6 +7,8 @@ Keyword Property SQ_ShipDebrisKeyword Auto Const mandatory
 { add keyword to orbit location when quest is running to block other quests from starting up here }
 LocationAlias Property OrbitLocation Auto Const mandatory
 { add keyword to this location }
+Location Property theOrbitLocation Auto Hidden ; Added location property to store location from startup so that keyword can properly be removed on shutdown - Bobbyclue 10/1/23
+{ add keyword to this location }
 
 ;-- Functions ---------------------------------------
 
@@ -19,8 +21,8 @@ Event OnQuestShutdown()
 EndEvent
 
 Function AddKeywordToLocation(Bool addKeyword)
-  Location theOrbitLocation = OrbitLocation.GetLocation() ; #DEBUG_LINE_NO:18
   If addKeyword ; #DEBUG_LINE_NO:20
+    theOrbitLocation = OrbitLocation.GetLocation() ; Moved inside of keyword check and changed to reference property instead of local var - Bobbyclue 10/1/23
     theOrbitLocation.addKeyword(SQ_ShipDebrisKeyword) ; #DEBUG_LINE_NO:21
   Else ; #DEBUG_LINE_NO:
     theOrbitLocation.RemoveKeyword(SQ_ShipDebrisKeyword) ; #DEBUG_LINE_NO:23

--- a/Scripts/Source/sq_shipdebrisscript.psc
+++ b/Scripts/Source/sq_shipdebrisscript.psc
@@ -1,0 +1,28 @@
+ScriptName SQ_ShipDebrisScript Extends Quest
+
+;-- Variables ---------------------------------------
+
+;-- Properties --------------------------------------
+Keyword Property SQ_ShipDebrisKeyword Auto Const mandatory
+{ add keyword to orbit location when quest is running to block other quests from starting up here }
+LocationAlias Property OrbitLocation Auto Const mandatory
+{ add keyword to this location }
+
+;-- Functions ---------------------------------------
+
+Event OnQuestStarted()
+  Self.AddKeywordToLocation(True) ; #DEBUG_LINE_NO:10
+EndEvent
+
+Event OnQuestShutdown()
+  Self.AddKeywordToLocation(False) ; #DEBUG_LINE_NO:14
+EndEvent
+
+Function AddKeywordToLocation(Bool addKeyword)
+  Location theOrbitLocation = OrbitLocation.GetLocation() ; #DEBUG_LINE_NO:18
+  If addKeyword ; #DEBUG_LINE_NO:20
+    theOrbitLocation.addKeyword(SQ_ShipDebrisKeyword) ; #DEBUG_LINE_NO:21
+  Else ; #DEBUG_LINE_NO:
+    theOrbitLocation.RemoveKeyword(SQ_ShipDebrisKeyword) ; #DEBUG_LINE_NO:23
+  EndIf ; #DEBUG_LINE_NO:
+EndFunction


### PR DESCRIPTION
Fix SQ_ShipDebrisScript fails to shutdown quest #287 

This edit stores the location in this script's location alias in a property when the attached quest starts up, and properly removes the added keyword from said location when the quest shuts down. The result being that the ship debris quests will always shut down properly even when fast traveling away from their location rather than only grav jumping.
Compiled script for testing:
[sq_shipdebrisscript.zip](https://github.com/Starfield-Community-Patch/Starfield-Community-Patch/files/12777897/sq_shipdebrisscript.zip)

Testing details can be found in #287 Quests should properly shut down with this fix. 

I would definitely recommend testing this fix and the issue, much of my information on it is from outside of the game currently.