### PR TITLE
Bump Spriggit version.  Reset ModHeader version to default

### DIFF
--- a/spriggit/RecordData.yaml
+++ b/spriggit/RecordData.yaml
@@ -1,13 +1,12 @@
 SpriggitSource:
   PackageName: Spriggit.Yaml.Starfield
-  Version: 0.4
+  Version: 0.6
 ModKey: StarfieldCommunityPatch.esm
 GameRelease: Starfield
 ModHeader:
   Flags:
   - Master
   - Localized
-  Version: 2109106
   FormVersion: 555
   Stats:
     Version: 0.96


### PR DESCRIPTION
- Fix for not including Starfield.esm master
- Made versions match default mod given by Elm a bit more