### PR TITLE
Spriggit bump to 0.9.  Some record definitions added

### DIFF
--- a/.spriggit
+++ b/.spriggit
@@ -1,5 +1,5 @@
 {
   "PackageName": "Spriggit.Yaml",
   "Release": "Starfield",
-  "Version": "0.4"
+  "Version": "0.9"
 }

--- a/spriggit/ConstructibleObjects/co_SMS_ScanJammer01.yaml
+++ b/spriggit/ConstructibleObjects/co_SMS_ScanJammer01.yaml
@@ -1,0 +1,47 @@
+FormKey: 1AD84D:Starfield.esm
+EditorID: co_SMS_ScanJammer01
+Description:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Ein Scanstörer, der deine Chance um 10 % erhöht, bei einem Schiffsscan durchzuschlüpfen, wenn du ein Frachtraumschild verwendest und Schmuggelware transportierst.
+  - Language: English
+    String: A Scan Jammer that increases your chance of evasion during a ship scan by 10% if you're using a shielded cargo module and carrying contraband.
+  - Language: Spanish
+    String: Inhibidor de escáneres que aumenta un 10 % tus probabilidades de evitar que las naves de defensa detecten tu contrabando si llevas un módulo de carga oculta.
+  - Language: French
+    String: Un brouilleur de scan qui diminue les chances de vous faire détecter de 10 % lorsque vous transportez de la contrebande lors d'un scan de vaisseau, à condition de posséder un module de soute blindée.
+  - Language: Italian
+    String: Un disturbatore scansioni che aumenta del 10% la tua probabilità di elusione durante una scansione della nave se usi un modulo di carico schermato e trasporti merce di contrabbando.
+  - Language: Japanese
+    String: スキャンジャマーは、シールド貨物モジュールで禁制品を運んでいる場合に、船のスキャンを回避できる確率を10%上げる
+  - Language: Polish
+    String: Zakłócacz skanerów, który zwiększa twoją szansę na uniknięcie wykrycia przewożonej kontrabandy o 10%, jeśli używasz osłanianego modułu ładowni.
+  - Language: Portuguese_Brazil
+    String: Um Bloqueador que aumenta em 10% suas chances de escapar de uma varredura de nave se você estiver usando um módulo de carga oculto e carregando contrabando.
+WorkbenchKeyword: 29C480:Starfield.esm
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Unknown1: 0x000000
+  Unknown2: 17620
+  Data:
+    MutagenObjectType: HasKeywordConditionData
+    FirstParameter: 10C4AB:Starfield.esm
+  ComparisonValue: 1
+- MutagenObjectType: ConditionFloat
+  CompareOperator: GreaterThanOrEqualTo
+  Unknown1: 0x000000
+  Unknown2: 17620
+  Data:
+    MutagenObjectType: GetLevelConditionData
+    RunOnType: Reference
+    Reference: 000014:Starfield.esm
+  ComparisonValue: 3
+CreatedObject: 1AD850:Starfield.esm
+AmountProduced: 1
+MenuSortOrder: 55.25
+LearnMethod: DefaultOrConditions
+Value: 3000
+Categories:
+- 29C477:Starfield.esm
+RECF: 0

--- a/spriggit/ConstructibleObjects/co_SMS_ScanJammer02_DualFrequency.yaml
+++ b/spriggit/ConstructibleObjects/co_SMS_ScanJammer02_DualFrequency.yaml
@@ -1,0 +1,50 @@
+FormKey: 1AD84C:Starfield.esm
+EditorID: co_SMS_ScanJammer02_DualFrequency
+Description:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Ein Scanstörer, der deine Chance um 30 % erhöht, bei einem Schiffsscan durchzuschlüpfen, wenn du ein Frachtraumschild verwendest und Schmuggelware transportierst.
+  - Language: English
+    String: A Scan Jammer that increases your chance of evasion during a ship scan by 30% if you're using a shielded cargo module and carrying contraband.
+  - Language: Spanish
+    String: Inhibidor de escáneres que aumenta un 30 % tus probabilidades de evitar que las naves de defensa detecten tu contrabando si llevas un módulo de carga oculta.
+  - Language: French
+    String: Un brouilleur de scan qui diminue les chances de vous faire détecter de 30 % lorsque vous transportez de la contrebande lors d'un scan de vaisseau, à condition de posséder un module de soute blindée.
+  - Language: Italian
+    String: Un disturbatore scansioni che aumenta del 30% la tua probabilità di elusione durante una scansione della nave se usi un modulo di carico schermato e trasporti merce di contrabbando.
+  - Language: Japanese
+    String: スキャンジャマーは、シールド貨物モジュールで禁制品を運んでいる場合に、船のスキャンを回避できる確率を30%上げる
+  - Language: Polish
+    String: Zakłócacz skanerów, który zwiększa twoją szansę na uniknięcie wykrycia przewożonej kontrabandy o 30%, jeśli używasz osłanianego modułu ładowni.
+  - Language: Portuguese_Brazil
+    String: Um Bloqueador que aumenta em 30% suas chances de escapar de uma varredura de nave se você estiver usando um módulo de carga oculto e carregando contrabando.
+WorkbenchKeyword: 29C480:Starfield.esm
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Unknown1: 0x000000
+  Unknown2: 17620
+  Data:
+    MutagenObjectType: HasKeywordConditionData
+    FirstParameter: 10C4AB:Starfield.esm
+  ComparisonValue: 1
+- MutagenObjectType: ConditionFloat
+  CompareOperator: GreaterThanOrEqualTo
+  Unknown1: 0x000000
+  Unknown2: 17620
+  Data:
+    MutagenObjectType: GetLevelConditionData
+    RunOnType: Reference
+    Reference: 000014:Starfield.esm
+  ComparisonValue: 10
+RequiredPerks:
+- Perk: 2C59DC:Starfield.esm
+  Rank: 1
+CreatedObject: 1AD84F:Starfield.esm
+AmountProduced: 1
+MenuSortOrder: 55.375
+LearnMethod: DefaultOrConditions
+Value: 5000
+Categories:
+- 29C477:Starfield.esm
+RECF: 0

--- a/spriggit/ConstructibleObjects/co_SMS_ScanJammer03_MultiFrequency.yaml
+++ b/spriggit/ConstructibleObjects/co_SMS_ScanJammer03_MultiFrequency.yaml
@@ -1,0 +1,50 @@
+FormKey: 1AD84B:Starfield.esm
+EditorID: co_SMS_ScanJammer03_MultiFrequency
+Description:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Ein Scanstörer, der deine Chance um 50 % erhöht, bei einem Schiffsscan durchzuschlüpfen, wenn du ein Frachtraumschild verwendest und Schmuggelware transportierst.
+  - Language: English
+    String: A Scan Jammer that increases your chance of evasion during a ship scan by 50% if you're using a shielded cargo module and carrying contraband.
+  - Language: Spanish
+    String: Inhibidor de escáneres que aumenta un 50 % tus probabilidades de evitar que las naves de defensa detecten tu contrabando si llevas un módulo de carga oculta.
+  - Language: French
+    String: Un brouilleur de scan qui diminue les chances de vous faire détecter de 50 % lorsque vous transportez de la contrebande lors d'un scan de vaisseau, à condition de posséder un module de soute blindée.
+  - Language: Italian
+    String: Un disturbatore scansioni che aumenta del 50% la tua probabilità di elusione durante una scansione della nave se usi un modulo di carico schermato e trasporti merce di contrabbando.
+  - Language: Japanese
+    String: スキャンジャマーは、シールド貨物モジュールで禁制品を運んでいる場合に、船のスキャンを回避できる確率を50%上げる
+  - Language: Polish
+    String: Zakłócacz skanerów, który zwiększa twoją szansę na uniknięcie wykrycia przewożonej kontrabandy o 50%, jeśli używasz osłanianego modułu ładowni.
+  - Language: Portuguese_Brazil
+    String: Um Bloqueador que aumenta em 50% suas chances de escapar de uma varredura de nave se você estiver usando um módulo de carga oculto e carregando contrabando.
+WorkbenchKeyword: 29C480:Starfield.esm
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Unknown1: 0x000000
+  Unknown2: 17620
+  Data:
+    MutagenObjectType: HasKeywordConditionData
+    FirstParameter: 10C4AB:Starfield.esm
+  ComparisonValue: 1
+- MutagenObjectType: ConditionFloat
+  CompareOperator: GreaterThanOrEqualTo
+  Unknown1: 0x000000
+  Unknown2: 17620
+  Data:
+    MutagenObjectType: GetLevelConditionData
+    RunOnType: Reference
+    Reference: 000014:Starfield.esm
+  ComparisonValue: 16
+RequiredPerks:
+- Perk: 2C59DC:Starfield.esm
+  Rank: 2
+CreatedObject: 1AD84E:Starfield.esm
+AmountProduced: 1
+MenuSortOrder: 55.4375
+LearnMethod: DefaultOrConditions
+Value: 10000
+Categories:
+- 29C477:Starfield.esm
+RECF: 0

--- a/spriggit/ConstructibleObjects/co_gun_mod_HardTarget_Mag_Penetrator.yaml
+++ b/spriggit/ConstructibleObjects/co_gun_mod_HardTarget_Mag_Penetrator.yaml
@@ -1,0 +1,43 @@
+FormKey: 0454B2:Starfield.esm
+EditorID: co_gun_mod_HardTarget_Mag_Penetrator
+Description:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Unglaublich starke Geschosse, die mehrere Gegner durchdringen können.
+  - Language: English
+    String: Incredibly powerful rounds that can pass through multiple enemies.
+  - Language: Spanish
+    String: Munición con una potencia tremenda que puede atravesar a varios enemigos.
+  - Language: French
+    String: Munitions extrêmement puissantes qui peuvent traverser plusieurs adversaires.
+  - Language: Italian
+    String: Proiettili straordinariamente potenti in grado di trapassare più di un nemico.
+  - Language: Japanese
+    String: 複数の敵を貫通できる、とても強力な弾丸
+  - Language: Polish
+    String: Niezwykle potężna amunicja zdolna przebić kilku przeciwników.
+  - Language: Portuguese_Brazil
+    String: Munição incrivelmente forte que pode atravessar diversos inimigos.
+WorkbenchKeyword: 2CE1C0:Starfield.esm
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Unknown1: 0x000000
+  Unknown2: 17620
+  Data:
+    MutagenObjectType: IsResearchCompleteConditionData
+    FirstParameter: 380C4D:Starfield.esm
+  ComparisonValue: 1
+ConstructableComponents:
+- Component: 0057C1:Starfield.esm
+  Count: 3
+- Component: 0057D3:Starfield.esm
+  Count: 4
+- Component: 077828:Starfield.esm
+  Count: 3
+CreatedObject: 12D03D:Starfield.esm
+AmountProduced: 1
+LearnMethod: DefaultOrConditions
+Categories:
+- 2D01F2:Starfield.esm
+RECF: 0

--- a/spriggit/ConstructibleObjects/co_gun_mod_Lawgiver_Mag_Penetrator.yaml
+++ b/spriggit/ConstructibleObjects/co_gun_mod_Lawgiver_Mag_Penetrator.yaml
@@ -1,0 +1,43 @@
+FormKey: 057561:Starfield.esm
+EditorID: co_gun_mod_Lawgiver_Mag_Penetrator
+Description:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Unglaublich starke Geschosse, die mehrere Gegner durchdringen können.
+  - Language: English
+    String: Incredibly powerful rounds that can pass through multiple enemies.
+  - Language: Spanish
+    String: Munición con una potencia tremenda que puede atravesar a varios enemigos.
+  - Language: French
+    String: Munitions extrêmement puissantes qui peuvent traverser plusieurs adversaires.
+  - Language: Italian
+    String: Proiettili straordinariamente potenti in grado di trapassare più di un nemico.
+  - Language: Japanese
+    String: 複数の敵を貫通できる、とても強力な弾丸
+  - Language: Polish
+    String: Niezwykle potężna amunicja zdolna przebić kilku przeciwników.
+  - Language: Portuguese_Brazil
+    String: Munição incrivelmente forte que pode atravessar diversos inimigos.
+WorkbenchKeyword: 2CE1C0:Starfield.esm
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Unknown1: 0x000000
+  Unknown2: 17620
+  Data:
+    MutagenObjectType: IsResearchCompleteConditionData
+    FirstParameter: 380C4D:Starfield.esm
+  ComparisonValue: 1
+ConstructableComponents:
+- Component: 0057C1:Starfield.esm
+  Count: 3
+- Component: 0057D3:Starfield.esm
+  Count: 4
+- Component: 077828:Starfield.esm
+  Count: 3
+CreatedObject: 128C6C:Starfield.esm
+AmountProduced: 1
+LearnMethod: DefaultOrConditions
+Categories:
+- 2D01F2:Starfield.esm
+RECF: 0

--- a/spriggit/ConstructibleObjects/co_gun_mod_MagSniper_Mag_Penetrator.yaml
+++ b/spriggit/ConstructibleObjects/co_gun_mod_MagSniper_Mag_Penetrator.yaml
@@ -1,0 +1,43 @@
+FormKey: 045BAF:Starfield.esm
+EditorID: co_gun_mod_MagSniper_Mag_Penetrator
+Description:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Unglaublich starke Geschosse, die mehrere Gegner durchdringen können.
+  - Language: English
+    String: Incredibly powerful rounds that can pass through multiple enemies.
+  - Language: Spanish
+    String: Munición con una potencia tremenda que puede atravesar a varios enemigos.
+  - Language: French
+    String: Munitions extrêmement puissantes qui peuvent traverser plusieurs adversaires.
+  - Language: Italian
+    String: Proiettili straordinariamente potenti in grado di trapassare più di un nemico.
+  - Language: Japanese
+    String: 複数の敵を貫通できる、とても強力な弾丸
+  - Language: Polish
+    String: Niezwykle potężna amunicja zdolna przebić kilku przeciwników.
+  - Language: Portuguese_Brazil
+    String: Munição incrivelmente forte que pode atravessar diversos inimigos.
+WorkbenchKeyword: 2CE1C0:Starfield.esm
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Unknown1: 0x000000
+  Unknown2: 17620
+  Data:
+    MutagenObjectType: IsResearchCompleteConditionData
+    FirstParameter: 380C4D:Starfield.esm
+  ComparisonValue: 1
+ConstructableComponents:
+- Component: 0057C1:Starfield.esm
+  Count: 3
+- Component: 0057D3:Starfield.esm
+  Count: 4
+- Component: 077828:Starfield.esm
+  Count: 3
+CreatedObject: 12A784:Starfield.esm
+AmountProduced: 1
+LearnMethod: DefaultOrConditions
+Categories:
+- 2D01F2:Starfield.esm
+RECF: 0

--- a/spriggit/ConstructibleObjects/co_gun_mod_Razorback_Mag_Penetrator.yaml
+++ b/spriggit/ConstructibleObjects/co_gun_mod_Razorback_Mag_Penetrator.yaml
@@ -1,0 +1,43 @@
+FormKey: 044C30:Starfield.esm
+EditorID: co_gun_mod_Razorback_Mag_Penetrator
+Description:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Unglaublich starke Geschosse, die mehrere Gegner durchdringen können.
+  - Language: English
+    String: Incredibly powerful rounds that can pass through multiple enemies.
+  - Language: Spanish
+    String: Munición con una potencia tremenda que puede atravesar a varios enemigos.
+  - Language: French
+    String: Munitions extrêmement puissantes qui peuvent traverser plusieurs adversaires.
+  - Language: Italian
+    String: Proiettili straordinariamente potenti in grado di trapassare più di un nemico.
+  - Language: Japanese
+    String: 複数の敵を貫通できる、とても強力な弾丸
+  - Language: Polish
+    String: Niezwykle potężna amunicja zdolna przebić kilku przeciwników.
+  - Language: Portuguese_Brazil
+    String: Munição incrivelmente forte que pode atravessar diversos inimigos.
+WorkbenchKeyword: 2CE1C0:Starfield.esm
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Unknown1: 0x000000
+  Unknown2: 17620
+  Data:
+    MutagenObjectType: IsResearchCompleteConditionData
+    FirstParameter: 380C4D:Starfield.esm
+  ComparisonValue: 1
+ConstructableComponents:
+- Component: 0057C1:Starfield.esm
+  Count: 3
+- Component: 0057D3:Starfield.esm
+  Count: 4
+- Component: 077828:Starfield.esm
+  Count: 3
+CreatedObject: 1298AE:Starfield.esm
+AmountProduced: 1
+LearnMethod: DefaultOrConditions
+Categories:
+- 2D01F2:Starfield.esm
+RECF: 0

--- a/spriggit/ConstructibleObjects/co_gun_mod_Regulator_Mag_Penetrator.yaml
+++ b/spriggit/ConstructibleObjects/co_gun_mod_Regulator_Mag_Penetrator.yaml
@@ -1,0 +1,43 @@
+FormKey: 057579:Starfield.esm
+EditorID: co_gun_mod_Regulator_Mag_Penetrator
+Description:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Unglaublich starke Geschosse, die mehrere Gegner durchdringen können.
+  - Language: English
+    String: Incredibly powerful rounds that can pass through multiple enemies.
+  - Language: Spanish
+    String: Munición con una potencia tremenda que puede atravesar a varios enemigos.
+  - Language: French
+    String: Munitions extrêmement puissantes qui peuvent traverser plusieurs adversaires.
+  - Language: Italian
+    String: Proiettili straordinariamente potenti in grado di trapassare più di un nemico.
+  - Language: Japanese
+    String: 複数の敵を貫通できる、とても強力な弾丸
+  - Language: Polish
+    String: Niezwykle potężna amunicja zdolna przebić kilku przeciwników.
+  - Language: Portuguese_Brazil
+    String: Munição incrivelmente forte que pode atravessar diversos inimigos.
+WorkbenchKeyword: 2CE1C0:Starfield.esm
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Unknown1: 0x000000
+  Unknown2: 17620
+  Data:
+    MutagenObjectType: IsResearchCompleteConditionData
+    FirstParameter: 380C4D:Starfield.esm
+  ComparisonValue: 1
+ConstructableComponents:
+- Component: 0057C1:Starfield.esm
+  Count: 3
+- Component: 0057D3:Starfield.esm
+  Count: 4
+- Component: 077828:Starfield.esm
+  Count: 3
+CreatedObject: 12A0B0:Starfield.esm
+AmountProduced: 1
+LearnMethod: DefaultOrConditions
+Categories:
+- 2D01F2:Starfield.esm
+RECF: 0

--- a/spriggit/ConstructibleObjects/co_gun_mod_Tombstone_Mag_Penetrator.yaml
+++ b/spriggit/ConstructibleObjects/co_gun_mod_Tombstone_Mag_Penetrator.yaml
@@ -1,0 +1,43 @@
+FormKey: 044C4D:Starfield.esm
+EditorID: co_gun_mod_Tombstone_Mag_Penetrator
+Description:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Unglaublich starke Geschosse, die mehrere Gegner durchdringen können.
+  - Language: English
+    String: Incredibly powerful rounds that can pass through multiple enemies.
+  - Language: Spanish
+    String: Munición con una potencia tremenda que puede atravesar a varios enemigos.
+  - Language: French
+    String: Munitions extrêmement puissantes qui peuvent traverser plusieurs adversaires.
+  - Language: Italian
+    String: Proiettili straordinariamente potenti in grado di trapassare più di un nemico.
+  - Language: Japanese
+    String: 複数の敵を貫通できる、とても強力な弾丸
+  - Language: Polish
+    String: Niezwykle potężna amunicja zdolna przebić kilku przeciwników.
+  - Language: Portuguese_Brazil
+    String: Munição incrivelmente forte que pode atravessar diversos inimigos.
+WorkbenchKeyword: 2CE1C0:Starfield.esm
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Unknown1: 0x000000
+  Unknown2: 17620
+  Data:
+    MutagenObjectType: IsResearchCompleteConditionData
+    FirstParameter: 380C4D:Starfield.esm
+  ComparisonValue: 1
+ConstructableComponents:
+- Component: 0057C1:Starfield.esm
+  Count: 3
+- Component: 0057D3:Starfield.esm
+  Count: 4
+- Component: 077828:Starfield.esm
+  Count: 3
+CreatedObject: 128C4C:Starfield.esm
+AmountProduced: 1
+LearnMethod: DefaultOrConditions
+Categories:
+- 2D01F2:Starfield.esm
+RECF: 0

--- a/spriggit/ConstructibleObjects/co_gun_mod_UrbanEagle_Mag_Penetrator.yaml
+++ b/spriggit/ConstructibleObjects/co_gun_mod_UrbanEagle_Mag_Penetrator.yaml
@@ -1,0 +1,43 @@
+FormKey: 07C747:Starfield.esm
+EditorID: co_gun_mod_UrbanEagle_Mag_Penetrator
+Description:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Unglaublich starke Geschosse, die mehrere Gegner durchdringen können.
+  - Language: English
+    String: Incredibly powerful rounds that can pass through multiple enemies.
+  - Language: Spanish
+    String: Munición con una potencia tremenda que puede atravesar a varios enemigos.
+  - Language: French
+    String: Munitions extrêmement puissantes qui peuvent traverser plusieurs adversaires.
+  - Language: Italian
+    String: Proiettili straordinariamente potenti in grado di trapassare più di un nemico.
+  - Language: Japanese
+    String: 複数の敵を貫通できる、とても強力な弾丸
+  - Language: Polish
+    String: Niezwykle potężna amunicja zdolna przebić kilku przeciwników.
+  - Language: Portuguese_Brazil
+    String: Munição incrivelmente forte que pode atravessar diversos inimigos.
+WorkbenchKeyword: 2CE1C0:Starfield.esm
+Conditions:
+- MutagenObjectType: ConditionFloat
+  Unknown1: 0x000000
+  Unknown2: 17620
+  Data:
+    MutagenObjectType: IsResearchCompleteConditionData
+    FirstParameter: 380C4D:Starfield.esm
+  ComparisonValue: 1
+ConstructableComponents:
+- Component: 0057C1:Starfield.esm
+  Count: 3
+- Component: 0057D3:Starfield.esm
+  Count: 4
+- Component: 077828:Starfield.esm
+  Count: 3
+CreatedObject: 133A6B:Starfield.esm
+AmountProduced: 1
+LearnMethod: DefaultOrConditions
+Categories:
+- 2D01F2:Starfield.esm
+RECF: 0

--- a/spriggit/Globals/SFCP_Version_Major.yaml
+++ b/spriggit/Globals/SFCP_Version_Major.yaml
@@ -1,0 +1,3 @@
+FormKey: 000801:StarfieldCommunityPatch.esm
+EditorID: SFCP_Version_Major
+Data: 0

--- a/spriggit/Globals/SFCP_Version_Minor.yaml
+++ b/spriggit/Globals/SFCP_Version_Minor.yaml
@@ -1,0 +1,3 @@
+FormKey: 000802:StarfieldCommunityPatch.esm
+EditorID: SFCP_Version_Minor
+Data: 0

--- a/spriggit/Globals/SFCP_Version_Patch.yaml
+++ b/spriggit/Globals/SFCP_Version_Patch.yaml
@@ -1,0 +1,3 @@
+FormKey: 000803:StarfieldCommunityPatch.esm
+EditorID: SFCP_Version_Patch
+Data: 2

--- a/spriggit/MagicEffects/ArtifactPowerVoidForm_Effect.yaml
+++ b/spriggit/MagicEffects/ArtifactPowerVoidForm_Effect.yaml
@@ -1,0 +1,55 @@
+FormKey: 2C7788:Starfield.esm
+EditorID: ArtifactPowerVoidForm_Effect
+Name:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Leere-Form
+  - Language: English
+    String: Void Form
+  - Language: Spanish
+    String: Forma del vacío
+  - Language: French
+    String: Forme du Néant
+  - Language: Italian
+    String: Forma del vuoto
+  - Language: Japanese
+    String: ヴォイドフォーム
+  - Language: Polish
+    String: Kształt pustki
+  - Language: Portuguese_Brazil
+    String: Forma Vazia
+Keywords:
+- 129573:Starfield.esm
+MovementType: 179DC1:Starfield.esm
+EnchantShader: 179DC2:Starfield.esm
+Sounds:
+- Unknown: 5
+  Sound:
+    Start: f10a421a-a5c1-e5c5-52ed-73eba74ec1ba
+    Stop: 5d4a4d0d-0268-10b9-a7b7-150d43e78db6
+- Unknown: 3
+  Sound:
+    Start: 06644b08-c615-fb05-04cc-1d089df704ae
+- Unknown: 1
+  Sound:
+    Start: a9bd4d18-e32f-c805-dc14-82e718741f96
+Description:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Hülle dich in die Leere und werde <dur> Sek. lang unsichtbar.
+  - Language: English
+    String: Cloak yourself in the void and become invisible for <dur> seconds.
+  - Language: Spanish
+    String: Ocúltate en el vacío y vuélvete invisible durante <dur> segundos.
+  - Language: French
+    String: Enveloppez-vous de vide et devenez invisible pendant <dur> secondes.
+  - Language: Italian
+    String: Ti mimetizzi con il vuoto e diventi invisibile per <dur> secondi.
+  - Language: Japanese
+    String: 虚空を身にまとい、<dur>秒間透明になる
+  - Language: Polish
+    String: Ukryj się w pustce i uzyskaj niewidzialność na <dur> s.
+  - Language: Portuguese_Brazil
+    String: Esconda-se no próprio vazio e fique invisível por <dur> s.

--- a/spriggit/MagicEffects/Chameleon_Effect_NoVisual.yaml
+++ b/spriggit/MagicEffects/Chameleon_Effect_NoVisual.yaml
@@ -1,0 +1,42 @@
+FormKey: 000804:StarfieldCommunityPatch.esm
+EditorID: Chameleon_Effect_NoVisual
+Name:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Getarnt
+  - Language: English
+    String: Camouflaged
+  - Language: Spanish
+    String: Camuflada
+  - Language: French
+    String: Camouflé
+  - Language: Italian
+    String: Mimetico
+  - Language: Japanese
+    String: 迷彩
+  - Language: Polish
+    String: Kamuflaż
+  - Language: Portuguese_Brazil
+    String: Camuflado
+Keywords:
+- 03E1E5:Starfield.esm
+Description:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Im Schleichmodus und bewegungslos nahezu unsichtbar.
+  - Language: English
+    String: Nearly invisible while sneaking and immoble.
+  - Language: Spanish
+    String: Prácticamente invisible durante el sigilo y al permanecer inmóvil.
+  - Language: French
+    String: Presque invisible en cas de déplacement furtif ou d'immobilité.
+  - Language: Italian
+    String: Quasi invisibile quando sei immobile o ti muovi furtivamente.
+  - Language: Japanese
+    String: ステルスして、動かないでいると透明に近い状態になる
+  - Language: Polish
+    String: Niemal całkowita niewidzialność podczas bezruchu w trakcie skradania się.
+  - Language: Portuguese_Brazil
+    String: Praticamente invisível quando não se move ou quando se esgueira.

--- a/spriggit/ObjectEffects/Ench_Legendary_Armor_Chameleon.yaml
+++ b/spriggit/ObjectEffects/Ench_Legendary_Armor_Chameleon.yaml
@@ -1,0 +1,62 @@
+FormKey: 1336BF:Starfield.esm
+EditorID: Ench_Legendary_Armor_Chameleon
+ODTY: 0
+Name:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Chamäleonpanzerung
+  - Language: English
+    String: Armor Chameleon
+  - Language: Spanish
+    String: Armadura camaleónica
+  - Language: French
+    String: Armure caméléon
+  - Language: Italian
+    String: Camaleonte corazza
+  - Language: Japanese
+    String: アーマーカメレオン
+  - Language: Polish
+    String: Pancerz kameleon
+  - Language: Portuguese_Brazil
+    String: Armadura Camaleão
+UnknownENIT: 0x000000000000000000000000000006000000000000000000000000
+Effects:
+- BaseEffect: 19AFF2:Starfield.esm
+  Data:
+    Magnitude: 50
+  Conditions:
+  - MutagenObjectType: ConditionFloat
+    Unknown1: 0x010812
+    Data:
+      MutagenObjectType: IsTrueForConditionFormConditionData
+      FirstParameter: 269A0B:Starfield.esm
+    ComparisonValue: 1
+  - MutagenObjectType: ConditionFloat
+    CompareOperator: LessThan
+    Unknown1: 0x010812
+    Data:
+      MutagenObjectType: GetPerkRankConditionData
+      FirstParameter: 2C555E:Starfield.esm
+    ComparisonValue: 3
+  EFIF: 0
+  MUID: 1
+- BaseEffect: 000804:StarfieldCommunityPatch.esm
+  Data:
+    Magnitude: 20
+  Conditions:
+  - MutagenObjectType: ConditionFloat
+    Unknown1: 0x010812
+    Data:
+      MutagenObjectType: IsTrueForConditionFormConditionData
+      FirstParameter: 269A0B:Starfield.esm
+    ComparisonValue: 1
+  - MutagenObjectType: ConditionFloat
+    CompareOperator: GreaterThanOrEqualTo
+    Unknown1: 0x010812
+    Data:
+      MutagenObjectType: GetPerkRankConditionData
+      FirstParameter: 2C555E:Starfield.esm
+    ComparisonValue: 3
+  EFIF: 0
+  MUID: 2

--- a/spriggit/RecordData.yaml
+++ b/spriggit/RecordData.yaml
@@ -1,18 +1,72 @@
 SpriggitSource:
   PackageName: Spriggit.Yaml.Starfield
-  Version: 0.7
+  Version: 0.9.0
 ModKey: StarfieldCommunityPatch.esm
 GameRelease: Starfield
 ModHeader:
   Flags:
   - Master
   - Localized
-  FormVersion: 555
   Stats:
-    Version: 0.96
-    NumRecords: 0
-    NextFormID: 2048
-  Author: Starfield Community
-  Description: Baseline bug fixes for Starfield
+    NumRecords: 338
+    NextFormID: 2053
+  Author: Starfield Modding Community
+  Description: A compilation of bug fixes assembled by Starfield Modders
   MasterReferences:
   - Master: Starfield.esm
+  - Master: BlueprintShips-Starfield.esm
+  OverriddenForms:
+  - 0109AD:Starfield.esm
+  - 0131B2:Starfield.esm
+  - 0131BB:Starfield.esm
+  - 019284:Starfield.esm
+  - 019287:Starfield.esm
+  - 03BD74:Starfield.esm
+  - 03BDD9:Starfield.esm
+  - 03BDDA:Starfield.esm
+  - 03BEF1:Starfield.esm
+  - 051A6F:Starfield.esm
+  - 051A7B:Starfield.esm
+  - 0D3AE9:Starfield.esm
+  - 10F644:Starfield.esm
+  - 12C618:Starfield.esm
+  - 12C632:Starfield.esm
+  - 146104:Starfield.esm
+  - 14610C:Starfield.esm
+  - 15E064:Starfield.esm
+  - 15E18B:Starfield.esm
+  - 18E0C1:Starfield.esm
+  - 18E0F5:Starfield.esm
+  - 1D56B1:Starfield.esm
+  - 1D56B2:Starfield.esm
+  - 1D56B3:Starfield.esm
+  - 1D5775:Starfield.esm
+  - 1E9CC0:Starfield.esm
+  - 1E9E43:Starfield.esm
+  - 1E9FC4:Starfield.esm
+  - 219542:Starfield.esm
+  - 219573:Starfield.esm
+  - 21B154:Starfield.esm
+  - 21B170:Starfield.esm
+  - 21B21A:Starfield.esm
+  - 21B2A1:Starfield.esm
+  - 22B6E4:Starfield.esm
+  - 22D907:Starfield.esm
+  - 22DAC4:Starfield.esm
+  - 23EB56:Starfield.esm
+  - 23ED95:Starfield.esm
+  - 23EE62:Starfield.esm
+  - 26C506:Starfield.esm
+  - 27104E:Starfield.esm
+  - 271076:Starfield.esm
+  - 27BC6F:Starfield.esm
+  - 27BC70:Starfield.esm
+  - 27BC76:Starfield.esm
+  - 27BC78:Starfield.esm
+  - 2B4AB4:Starfield.esm
+  - 2C334A:Starfield.esm
+  - 2C33C5:Starfield.esm
+  - 33A850:Starfield.esm
+  - 33A879:Starfield.esm
+  - 34B529:Starfield.esm
+  - 35B249:Starfield.esm

--- a/spriggit/Spells/ArtifactPowerVoidForm_Spell.yaml
+++ b/spriggit/Spells/ArtifactPowerVoidForm_Spell.yaml
@@ -1,0 +1,65 @@
+FormKey: 2C5A53:Starfield.esm
+EditorID: ArtifactPowerVoidForm_Spell
+ODTY: 0
+Name:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Leere-Form
+  - Language: English
+    String: Void Form
+  - Language: Spanish
+    String: Forma del vacío
+  - Language: French
+    String: Forme du Néant
+  - Language: Italian
+    String: Forma del vuoto
+  - Language: Japanese
+    String: ヴォイドフォーム
+  - Language: Polish
+    String: Kształt pustki
+  - Language: Portuguese_Brazil
+    String: Forma Vazia
+Keywords:
+- 1EC4E4:Starfield.esm
+- 1FD3CF:Starfield.esm
+- 2C5A61:Starfield.esm
+EquipmentType: 013F43:Starfield.esm
+Description:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: 'Verzerrt das Licht um dich und macht dich für eine gewisse Zeit fast unsichtbar. '
+  - Language: English
+    String: 'Warp the light around you, becoming nearly invisible for a duration. '
+  - Language: Spanish
+    String: 'Deforma la luz a tu alrededor, volviéndote invisible un tiempo determinado. '
+  - Language: French
+    String: 'Attire toute la lumière qui vous entoure et vous rend momentanément quasi invisible. '
+  - Language: Italian
+    String: 'Deforma la luce che ti attornia, diventando pressoché invisibile per un certo periodo. '
+  - Language: Japanese
+    String: '使用者周囲の光を屈曲させ、一定時間ほぼ不可視の状態となる '
+  - Language: Polish
+    String: 'Zakrzyw światło wokół siebie i na pewien czas zyskaj niemal całkowitą niewidzialność. '
+  - Language: Portuguese_Brazil
+    String: 'Você se envolve em luz e se torna praticamente invisível até o efeito acabar. '
+BaseCost: 45
+Flags:
+- ManualCostCalc
+CastType: FireAndForget
+Effects:
+- BaseEffect: 2C7788:Starfield.esm
+  Data:
+    Magnitude: 1000
+    Duration: 20
+  Conditions:
+  - MutagenObjectType: ConditionFloat
+    CompareOperator: NotEqualTo
+    Unknown1: 0x000000
+    Data:
+      MutagenObjectType: HasMagicEffectOrSpellKeywordConditionData
+      FirstParameter: 03E1E5:Starfield.esm
+    ComparisonValue: 1
+  EFIF: 0
+  MUID: 1

--- a/spriggit/Spells/abRejuvenation03.yaml
+++ b/spriggit/Spells/abRejuvenation03.yaml
@@ -1,0 +1,33 @@
+FormKey: 12601A:Starfield.esm
+EditorID: abRejuvenation03
+ODTY: 0
+EquipmentType: 013F44:Starfield.esm
+Description:
+  TargetLanguage: English
+Type:
+- Ability
+Effects:
+- BaseEffect: 102149:Starfield.esm
+  Data:
+    Magnitude: 1
+  Conditions:
+  - MutagenObjectType: ConditionFloat
+    CompareOperator: LessThan
+    Unknown1: 0x010812
+    Data:
+      MutagenObjectType: GetHealthPercentageConditionData
+    ComparisonValue: 1
+  EFIF: 0
+  MUID: 1
+- BaseEffect: 0622EA:Starfield.esm
+  Data:
+    Magnitude: 0.5
+  Conditions:
+  - MutagenObjectType: ConditionFloat
+    CompareOperator: LessThan
+    Unknown1: 0x010812
+    Data:
+      MutagenObjectType: GetHealthPercentageConditionData
+    ComparisonValue: 1
+  EFIF: 0
+  MUID: 2

--- a/spriggit/Spells/abRejuvenation04.yaml
+++ b/spriggit/Spells/abRejuvenation04.yaml
@@ -1,0 +1,33 @@
+FormKey: 12601B:Starfield.esm
+EditorID: abRejuvenation04
+ODTY: 0
+EquipmentType: 013F44:Starfield.esm
+Description:
+  TargetLanguage: English
+Type:
+- Ability
+Effects:
+- BaseEffect: 102149:Starfield.esm
+  Data:
+    Magnitude: 2
+  Conditions:
+  - MutagenObjectType: ConditionFloat
+    CompareOperator: LessThan
+    Unknown1: 0x010812
+    Data:
+      MutagenObjectType: GetHealthPercentageConditionData
+    ComparisonValue: 1
+  EFIF: 0
+  MUID: 2
+- BaseEffect: 0622EA:Starfield.esm
+  Data:
+    Magnitude: 0.5
+  Conditions:
+  - MutagenObjectType: ConditionFloat
+    CompareOperator: LessThan
+    Unknown1: 0x010812
+    Data:
+      MutagenObjectType: GetHealthPercentageConditionData
+    ComparisonValue: 1
+  EFIF: 0
+  MUID: 3

--- a/spriggit/Weapons/SWA_EM_Ballistic_EMP-200_lvl38.yaml
+++ b/spriggit/Weapons/SWA_EM_Ballistic_EMP-200_lvl38.yaml
@@ -1,0 +1,111 @@
+FormKey: 2184B7:Starfield.esm
+MajorRecordFlagsRaw: 4
+EditorID: SWA_EM_Ballistic_EMP-200_lvl38
+StarfieldMajorRecordFlags:
+- NotPlayable
+ODTY: 0
+Name:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Modulierter Dämpfer EM-200
+  - Language: English
+    String: EMP-200 modulated suppressor
+  - Language: Spanish
+    String: Supresor modulado EMP-200
+  - Language: French
+    String: Silencieux modulé EMP-200
+  - Language: Italian
+    String: Soppressore modulato EMP-200
+  - Language: Japanese
+    String: EMP-200変調サプレッサー
+  - Language: Polish
+    String: Tłumik modulowany EMP-200
+  - Language: Portuguese_Brazil
+    String: Supr. modular EMP-200
+Model:
+  FLLD: 0x01000000
+EquipmentType: 000046:Starfield.esm
+BlockBashImpactDataSet: 056A91:Starfield.esm
+Keywords:
+- 02226B:Starfield.esm
+- 160020:Starfield.esm
+- 249FB6:Starfield.esm
+Description:
+  TargetLanguage: English
+EmbeddedWeaponMod: Null
+SightedTransitionSeconds: 0.25
+AimDownSightTemplate: 04B246:Starfield.esm
+AimModel: 1818D7:Starfield.esm
+AccuracyBonus: 5
+AmmoType: 2184C0:Starfield.esm
+ProjectilesCount: 1
+WAM2Unknown1: 1
+MeleeOrCreature: {}
+PrimedExplosive: {}
+DryFire: {}
+Idle: {}
+Equip: {}
+Unequip: {}
+FastEquip: {}
+SoundLevel: Silent
+WAUDUnknown2: 3
+WTUR: 0x00000034C3000034430000B4C20000B44200003443000034430000803F
+ChargeCritBonus: 1
+AttackDamage: 1
+MinRange: 300
+MaxRange: 800
+OutOfRangeDamageMult: 0.5
+CritDamageMult: 2
+CriticalHitSpell: 02A704:Starfield.esm
+WDMGUnknown4: 1
+WDMGUnknown5: 1
+WDMGUnknown6: 1
+WDMGUnknown7: 1
+WDMGUnknown8: 1
+WDMGUnknown9: 1
+CritChanceIncMult: 1
+DamageTypes:
+- DamageType: 01EDE8:Starfield.esm
+  Value: 1
+- DamageType: 023190:Starfield.esm
+  Value: 42
+RepeatableFire: True
+AttackSeconds: 0.25
+AttackDelaySeconds: 0.6666667
+DisableShellCaseEject: True
+ShotsPerSecond: 1.5
+WFIRUnknown7: 0.6666667
+OverrideRateOfFire: True
+TriggerThresholdPrimaryTrigger: 0.33
+TriggerThresholdSecondStage: 0.33
+HasStagedTrigger: True
+HasDualTrigger: True
+BurstDelaySeconds: 0.3
+NonPlayable: True
+CannotDrop: True
+WFLGUnknown5: True
+WGENUnknown1: 12
+BaseWeight: 3
+BaseSpeed: 1
+AttackOxygenCost: 60
+General: "²\x02\0"
+WMELUnknown1: 2
+MeleeReach: 1
+MeleeStagger: Medium
+PowerRechargeTime: 0.6666667
+UsePower: True
+QNAMUnknown5: 1
+WRLOUnknown1: 0.6666667
+ReloadSpeed: 1
+FirstPersonModel:
+  File: ''
+  FLLD: 0x01000000
+ImpactDataSet: 137375:Starfield.esm
+ColorRemappingIndex: 3.4028235E+38
+WTRMUnknown1: 20
+WTRMUnknown3: 0.3
+WTRMUnknown4: 0.5
+WTRMUnknown5: 45
+MajorFlags:
+- NonPlayable

--- a/spriggit/Weapons/SWA_EM_Ballistic_EMP-80_lvl08.yaml
+++ b/spriggit/Weapons/SWA_EM_Ballistic_EMP-80_lvl08.yaml
@@ -1,0 +1,111 @@
+FormKey: 2184C1:Starfield.esm
+MajorRecordFlagsRaw: 4
+EditorID: SWA_EM_Ballistic_EMP-80_lvl08
+StarfieldMajorRecordFlags:
+- NotPlayable
+ODTY: 0
+Name:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Dämpfer EM-80
+  - Language: English
+    String: EMP-80 suppressor
+  - Language: Spanish
+    String: Supresor EMP-80
+  - Language: French
+    String: Silencieux EMP-80
+  - Language: Italian
+    String: Soppressore EMP-80
+  - Language: Japanese
+    String: EMP-80サプレッサー
+  - Language: Polish
+    String: Tłumik EMP-80
+  - Language: Portuguese_Brazil
+    String: Supressor EMP-80
+Model:
+  FLLD: 0x01000000
+EquipmentType: 000046:Starfield.esm
+BlockBashImpactDataSet: 056A91:Starfield.esm
+Keywords:
+- 02226B:Starfield.esm
+- 160020:Starfield.esm
+- 249FB6:Starfield.esm
+Description:
+  TargetLanguage: English
+EmbeddedWeaponMod: Null
+SightedTransitionSeconds: 0.25
+AimDownSightTemplate: 04B246:Starfield.esm
+AimModel: 1818D7:Starfield.esm
+AccuracyBonus: 5
+AmmoType: 2184C0:Starfield.esm
+ProjectilesCount: 1
+WAM2Unknown1: 1
+MeleeOrCreature: {}
+PrimedExplosive: {}
+DryFire: {}
+Idle: {}
+Equip: {}
+Unequip: {}
+FastEquip: {}
+SoundLevel: Silent
+WAUDUnknown2: 3
+WTUR: 0x00000034C3000034430000B4C20000B44200003443000034430000803F
+ChargeCritBonus: 1
+AttackDamage: 1
+MinRange: 300
+MaxRange: 800
+OutOfRangeDamageMult: 0.5
+CritDamageMult: 2
+CriticalHitSpell: 02A704:Starfield.esm
+WDMGUnknown4: 1
+WDMGUnknown5: 1
+WDMGUnknown6: 1
+WDMGUnknown7: 1
+WDMGUnknown8: 1
+WDMGUnknown9: 1
+CritChanceIncMult: 1
+DamageTypes:
+- DamageType: 01EDE8:Starfield.esm
+  Value: 1
+- DamageType: 023190:Starfield.esm
+  Value: 24
+RepeatableFire: True
+AttackSeconds: 0.25
+AttackDelaySeconds: 0.6666667
+DisableShellCaseEject: True
+ShotsPerSecond: 1.5
+WFIRUnknown7: 0.6666667
+OverrideRateOfFire: True
+TriggerThresholdPrimaryTrigger: 0.33
+TriggerThresholdSecondStage: 0.33
+HasStagedTrigger: True
+HasDualTrigger: True
+BurstDelaySeconds: 0.3
+NonPlayable: True
+CannotDrop: True
+WFLGUnknown5: True
+WGENUnknown1: 12
+BaseWeight: 3
+BaseSpeed: 1
+AttackOxygenCost: 60
+General: "°\x02\0"
+WMELUnknown1: 2
+MeleeReach: 1
+MeleeStagger: Medium
+PowerRechargeTime: 0.6666667
+UsePower: True
+QNAMUnknown5: 1
+WRLOUnknown1: 0.6666667
+ReloadSpeed: 1
+FirstPersonModel:
+  File: ''
+  FLLD: 0x01000000
+ImpactDataSet: 137375:Starfield.esm
+ColorRemappingIndex: 3.4028235E+38
+WTRMUnknown1: 20
+WTRMUnknown3: 0.3
+WTRMUnknown4: 0.5
+WTRMUnknown5: 45
+MajorFlags:
+- NonPlayable

--- a/spriggit/Weapons/SWB_EM_Ballistic_EMP-500_lvl16.yaml
+++ b/spriggit/Weapons/SWB_EM_Ballistic_EMP-500_lvl16.yaml
@@ -1,0 +1,110 @@
+FormKey: 2184A7:Starfield.esm
+MajorRecordFlagsRaw: 4
+EditorID: SWB_EM_Ballistic_EMP-500_lvl16
+StarfieldMajorRecordFlags:
+- NotPlayable
+ODTY: 0
+Name:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Stochastischer Dämpfer EM-500
+  - Language: English
+    String: EMP-500 stochastic suppressor
+  - Language: Spanish
+    String: Supresor estocástico EMP-500
+  - Language: French
+    String: Silencieux stocha. EMP-500
+  - Language: Italian
+    String: Soppressore stocastico EMP-500
+  - Language: Japanese
+    String: EMP-500推計サプレッサー
+  - Language: Polish
+    String: Tłumik stochastyczny EMP-500
+  - Language: Portuguese_Brazil
+    String: Supr. estocástico EMP-500
+Model:
+  FLLD: 0x01000000
+EquipmentType: 000046:Starfield.esm
+BlockBashImpactDataSet: 056A91:Starfield.esm
+Keywords:
+- 02226B:Starfield.esm
+- 16001F:Starfield.esm
+- 249FB6:Starfield.esm
+Description:
+  TargetLanguage: English
+EmbeddedWeaponMod: Null
+SightedTransitionSeconds: 0.25
+AimDownSightTemplate: 04B246:Starfield.esm
+AimModel: 1818D6:Starfield.esm
+AccuracyBonus: 5
+AmmoType: 2184BA:Starfield.esm
+ProjectilesCount: 1
+WAM2Unknown1: 1
+MeleeOrCreature: {}
+PrimedExplosive: {}
+DryFire: {}
+Idle: {}
+Equip: {}
+Unequip: {}
+FastEquip: {}
+SoundLevel: Silent
+WAUDUnknown2: 3
+WTUR: 0x00000034C3000034430000B4C20000B44200003443000034430000803F
+ChargeCritBonus: 1
+AttackDamage: 1
+MinRange: 300
+MaxRange: 800
+OutOfRangeDamageMult: 0.5
+CritDamageMult: 2
+CriticalHitSpell: 02A704:Starfield.esm
+WDMGUnknown4: 1
+WDMGUnknown5: 1
+WDMGUnknown6: 1
+WDMGUnknown7: 1
+WDMGUnknown8: 1
+WDMGUnknown9: 1
+CritChanceIncMult: 1
+DamageTypes:
+- DamageType: 01EDE8:Starfield.esm
+  Value: 1
+- DamageType: 023190:Starfield.esm
+  Value: 45
+RepeatableFire: True
+AttackSeconds: 0.25
+AttackDelaySeconds: 0.6666667
+DisableShellCaseEject: True
+ShotsPerSecond: 1.5
+WFIRUnknown7: 0.6666667
+OverrideRateOfFire: True
+TriggerThresholdPrimaryTrigger: 0.33
+TriggerThresholdSecondStage: 0.33
+HasStagedTrigger: True
+BurstDelaySeconds: 0.3
+NonPlayable: True
+CannotDrop: True
+WFLGUnknown5: True
+WGENUnknown1: 12
+BaseWeight: 3
+BaseSpeed: 1
+AttackOxygenCost: 90
+General: "´\x02\0"
+WMELUnknown1: 2
+MeleeReach: 1
+MeleeStagger: Medium
+PowerRechargeTime: 0.6666667
+UsePower: True
+QNAMUnknown5: 1
+WRLOUnknown1: 0.6666667
+ReloadSpeed: 1
+FirstPersonModel:
+  File: ''
+  FLLD: 0x01000000
+ImpactDataSet: 137376:Starfield.esm
+ColorRemappingIndex: 3.4028235E+38
+WTRMUnknown1: 30
+WTRMUnknown3: 0.3
+WTRMUnknown4: 0.5
+WTRMUnknown5: 50
+MajorFlags:
+- NonPlayable

--- a/spriggit/Weapons/SWB_Particle_Horizon_Disruptor_3320_Neutron_Turret_lvl26.yaml
+++ b/spriggit/Weapons/SWB_Particle_Horizon_Disruptor_3320_Neutron_Turret_lvl26.yaml
@@ -1,0 +1,107 @@
+FormKey: 14A8CD:Starfield.esm
+MajorRecordFlagsRaw: 4
+EditorID: SWB_Particle_Horizon_Disruptor_3320_Neutron_Turret_lvl26
+StarfieldMajorRecordFlags:
+- NotPlayable
+ODTY: 0
+Name:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Neutronengeschütz Disruptor 3320
+  - Language: English
+    String: Disruptor 3320  Neutron Turret
+  - Language: Spanish
+    String: Torreta de neutrones Disruptor 3320
+  - Language: French
+    String: Tourelle à neutrons Disruptor 3320
+  - Language: Italian
+    String: Torretta N Disruptor 3320
+  - Language: Japanese
+    String: ディスラプター3320中性子タレット
+  - Language: Polish
+    String: Wieżyczka neutronowa Disruptor 3320
+  - Language: Portuguese_Brazil
+    String: Torreta de Nêutrons Subversor 3320
+Model:
+  FLLD: 0x01000000
+EquipmentType: 000046:Starfield.esm
+BlockBashImpactDataSet: 056A91:Starfield.esm
+Keywords:
+- 1557AA:Starfield.esm
+- 1C9925:Starfield.esm
+- 249FB6:Starfield.esm
+- 32792C:Starfield.esm
+Description:
+  TargetLanguage: English
+EmbeddedWeaponMod: Null
+SightedTransitionSeconds: 0.25
+AimDownSightTemplate: 04B246:Starfield.esm
+AimModel: 146D38:Starfield.esm
+AccuracyBonus: 5
+AmmoType: 22F517:Starfield.esm
+ProjectilesCount: 1
+WAM2Unknown1: 1
+MeleeOrCreature: {}
+PrimedExplosive: {}
+DryFire: {}
+Idle: {}
+Equip: {}
+Unequip: {}
+FastEquip: {}
+SoundLevel: Silent
+WAUDUnknown2: 3
+WTUR: 0x01000034C200003442000070C20000A0400000B4420000B4420000803F
+ChargeCritBonus: 1
+AttackDamage: 29
+MinRange: 1250
+MaxRange: 3500
+OutOfRangeDamageMult: 1
+CritDamageMult: 2
+CriticalHitSpell: 0913C4:Starfield.esm
+WDMGUnknown4: 1
+WDMGUnknown5: 1
+WDMGUnknown6: 1
+WDMGUnknown7: 1
+WDMGUnknown8: 1
+WDMGUnknown9: 1
+CritChanceIncMult: 1
+DamageTypes:
+- DamageType: 01EDE8:Starfield.esm
+  Value: 29
+RepeatableFire: True
+AttackSeconds: 0.3
+AttackDelaySeconds: 0.4
+DisableShellCaseEject: True
+ShotsPerSecond: 2.5
+WFIRUnknown7: 0.4
+OverrideRateOfFire: True
+TriggerThresholdPrimaryTrigger: 0.33
+TriggerThresholdSecondStage: 0.33
+BurstDelaySeconds: 0.3
+NonPlayable: True
+CannotDrop: True
+WFLGUnknown4: True
+WGENUnknown1: 12
+BaseWeight: 3
+BaseSpeed: 1
+AttackOxygenCost: 150
+General: "¸\x02\0"
+WMELUnknown1: 2
+MeleeReach: 1
+MeleeStagger: Medium
+PowerRechargeTime: 0.4
+UsePower: True
+QNAMUnknown5: 1
+ReloadSpeed: 0.1
+FirstPersonModel:
+  File: ''
+  FLLD: 0x01000000
+ImpactDataSet: 137378:Starfield.esm
+ColorRemappingIndex: 3.4028235E+38
+WTRMUnknown1: 30
+WTRMUnknown3: 0.3
+WTRMUnknown4: 0.5
+WTRMUnknown5: 50
+MajorFlags:
+- NonPlayable

--- a/spriggit/Weapons/SWC_Ballistic_Horizon_Marauder_115N_Turret_lvl54.yaml
+++ b/spriggit/Weapons/SWC_Ballistic_Horizon_Marauder_115N_Turret_lvl54.yaml
@@ -1,0 +1,107 @@
+FormKey: 025FB6:Starfield.esm
+MajorRecordFlagsRaw: 4
+EditorID: SWC_Ballistic_Horizon_Marauder_115N_Turret_lvl54
+StarfieldMajorRecordFlags:
+- NotPlayable
+ODTY: 0
+Name:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Railgun-Geschütz Marauder 115N
+  - Language: English
+    String: Marauder 115N railgun Turret
+  - Language: Spanish
+    String: Torreta de riel Marauder 115N
+  - Language: French
+    String: Tourelle à canon électrique Marauder 115N
+  - Language: Italian
+    String: Torretta cannone a rotaia Marauder 115N
+  - Language: Japanese
+    String: マローダー115Nレールガンタレット
+  - Language: Polish
+    String: Wieżyczka z działkiem EM Marauder 115 N
+  - Language: Portuguese_Brazil
+    String: Torreta Canhão Elétrico Ladrão 115N
+Model:
+  FLLD: 0x01000000
+EquipmentType: 000046:Starfield.esm
+BlockBashImpactDataSet: 056A91:Starfield.esm
+Keywords:
+- 022269:Starfield.esm
+- 21A1BE:Starfield.esm
+- 249FB6:Starfield.esm
+- 32792C:Starfield.esm
+Description:
+  TargetLanguage: English
+EmbeddedWeaponMod: Null
+SightedTransitionSeconds: 0.25
+AimDownSightTemplate: 04B246:Starfield.esm
+AimModel: 1818E1:Starfield.esm
+AccuracyBonus: 5
+AmmoType: 22F50D:Starfield.esm
+ProjectilesCount: 1
+WAM2Unknown1: 1
+MeleeOrCreature: {}
+PrimedExplosive: {}
+DryFire: {}
+Idle: {}
+Equip: {}
+Unequip: {}
+FastEquip: {}
+SoundLevel: Silent
+WAUDUnknown2: 3
+WTUR: 0x01000034C200003442000070C20000A0400000B4420000B4420000803F
+ChargeCritBonus: 1
+AttackDamage: 81
+MinRange: 300
+MaxRange: 800
+OutOfRangeDamageMult: 0.5
+CritDamageMult: 2
+CriticalHitSpell: 02A6FD:Starfield.esm
+WDMGUnknown4: 1
+WDMGUnknown5: 1
+WDMGUnknown6: 1
+WDMGUnknown7: 1
+WDMGUnknown8: 1
+WDMGUnknown9: 1
+CritChanceIncMult: 1
+DamageTypes:
+- DamageType: 01EDE8:Starfield.esm
+  Value: 24
+AttackSeconds: 1.118
+AttackDelaySeconds: 0.6666667
+DisableShellCaseEject: True
+ShotsPerSecond: 1.5
+WFIRUnknown7: 0.6666667
+OverrideRateOfFire: True
+TriggerThresholdPrimaryTrigger: 0.33
+TriggerThresholdSecondStage: 0.33
+HasStagedTrigger: True
+BurstDelaySeconds: 0.3
+NonPlayable: True
+CannotDrop: True
+WFLGUnknown4: True
+WGENUnknown1: 12
+BaseWeight: 3
+BaseSpeed: 1
+AttackOxygenCost: 125
+General: "º\x02\0"
+WMELUnknown1: 2
+MeleeReach: 1
+MeleeStagger: Medium
+PowerRechargeTime: 0.6
+UsePower: True
+QNAMUnknown5: 1
+ReloadSpeed: 1
+FirstPersonModel:
+  File: ''
+  FLLD: 0x01000000
+ImpactDataSet: 137374:Starfield.esm
+ColorRemappingIndex: 3.4028235E+38
+WTRMUnknown1: 40
+WTRMUnknown3: 0.3
+WTRMUnknown4: 0.5
+WTRMUnknown5: 55
+MajorFlags:
+- NonPlayable

--- a/spriggit/Weapons/SWC_EM_Ballistic_EMP-1000_lvl20.yaml
+++ b/spriggit/Weapons/SWC_EM_Ballistic_EMP-1000_lvl20.yaml
@@ -1,0 +1,108 @@
+FormKey: 2184A6:Starfield.esm
+MajorRecordFlagsRaw: 4
+EditorID: SWC_EM_Ballistic_EMP-1000_lvl20
+StarfieldMajorRecordFlags:
+- NotPlayable
+ODTY: 0
+Name:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Breitbanddämpfer EM-1000
+  - Language: English
+    String: EMP-1000 broadband suppressor
+  - Language: Spanish
+    String: Supresor de banda ancha EMP-1000
+  - Language: French
+    String: Silencieux large b. EMP-1000
+  - Language: Italian
+    String: Soppressore di banda EMP-1000
+  - Language: Japanese
+    String: EMP-1000広帯域サプレッサー
+  - Language: Polish
+    String: Tłumik szerokopasmowy EMP-1000
+  - Language: Portuguese_Brazil
+    String: Supr. banda larga EMP-1000
+Model:
+  FLLD: 0x01000000
+EquipmentType: 000046:Starfield.esm
+BlockBashImpactDataSet: 056A91:Starfield.esm
+Keywords:
+- 02226B:Starfield.esm
+- 16001E:Starfield.esm
+- 249FB6:Starfield.esm
+Description:
+  TargetLanguage: English
+EmbeddedWeaponMod: Null
+SightedTransitionSeconds: 0.25
+AimDownSightTemplate: 04B246:Starfield.esm
+AimModel: 1818D5:Starfield.esm
+AccuracyBonus: 5
+AmmoType: 2184B9:Starfield.esm
+ProjectilesCount: 1
+WAM2Unknown1: 1
+MeleeOrCreature: {}
+PrimedExplosive: {}
+DryFire: {}
+Idle: {}
+Equip: {}
+Unequip: {}
+FastEquip: {}
+SoundLevel: Silent
+WAUDUnknown2: 3
+WTUR: 0x00000034C3000034430000B4C20000B44200003443000034430000803F
+ChargeCritBonus: 1
+AttackDamage: 1
+MinRange: 300
+MaxRange: 800
+OutOfRangeDamageMult: 0.5
+CritDamageMult: 2
+CriticalHitSpell: 02A704:Starfield.esm
+WDMGUnknown4: 1
+WDMGUnknown5: 1
+WDMGUnknown6: 1
+WDMGUnknown7: 1
+WDMGUnknown8: 1
+WDMGUnknown9: 1
+CritChanceIncMult: 1
+DamageTypes:
+- DamageType: 01EDE8:Starfield.esm
+  Value: 1
+- DamageType: 023190:Starfield.esm
+  Value: 54
+AttackSeconds: 0.25
+AttackDelaySeconds: 1.25
+DisableShellCaseEject: True
+ShotsPerSecond: 0.8
+WFIRUnknown7: 1.25
+TriggerThresholdPrimaryTrigger: 0.33
+TriggerThresholdSecondStage: 0.33
+HasStagedTrigger: True
+BurstDelaySeconds: 0.3
+NonPlayable: True
+CannotDrop: True
+WFLGUnknown5: True
+WGENUnknown1: 12
+BaseWeight: 3
+BaseSpeed: 1
+AttackOxygenCost: 150
+General: "¶\x02\0"
+WMELUnknown1: 2
+MeleeReach: 1
+MeleeStagger: Medium
+PowerRechargeTime: 1
+UsePower: True
+QNAMUnknown5: 1
+WRLOUnknown1: 1.25
+ReloadSpeed: 1
+FirstPersonModel:
+  File: ''
+  FLLD: 0x01000000
+ImpactDataSet: 137377:Starfield.esm
+ColorRemappingIndex: 3.4028235E+38
+WTRMUnknown1: 40
+WTRMUnknown3: 0.3
+WTRMUnknown4: 0.5
+WTRMUnknown5: 55
+MajorFlags:
+- NonPlayable

--- a/spriggit/Weapons/SWC_Particle_LightScythe_Obliterator_250MeV_Alpha_Turret_lvl76.yaml
+++ b/spriggit/Weapons/SWC_Particle_LightScythe_Obliterator_250MeV_Alpha_Turret_lvl76.yaml
@@ -1,0 +1,108 @@
+FormKey: 025FB4:Starfield.esm
+MajorRecordFlagsRaw: 4
+EditorID: SWC_Particle_LightScythe_Obliterator_250MeV_Alpha_Turret_lvl76
+StarfieldMajorRecordFlags:
+- NotPlayable
+ODTY: 0
+Name:
+  TargetLanguage: English
+  Values:
+  - Language: German
+    String: Alphageschütz Obliterator 250MeV
+  - Language: English
+    String: Obliterator 250MeV Alpha Turret
+  - Language: Spanish
+    String: Torreta alfa Obliterator de 250 MeV
+  - Language: French
+    String: Tourelle alpha Obliterator 250 MeV
+  - Language: Italian
+    String: Torretta A Obliterator 250 MeV
+  - Language: Japanese
+    String: オブリタレーター250MeVアルファタレット
+  - Language: Polish
+    String: Wieżyczka alfa Obliterator 250 MeV
+  - Language: Portuguese_Brazil
+    String: Torreta Alfa Obliterador 250MeV
+Model:
+  FLLD: 0x01000000
+EquipmentType: 000046:Starfield.esm
+BlockBashImpactDataSet: 056A91:Starfield.esm
+Keywords:
+- 1557AA:Starfield.esm
+- 15C565:Starfield.esm
+- 249FB6:Starfield.esm
+- 32792C:Starfield.esm
+Description:
+  TargetLanguage: English
+EmbeddedWeaponMod: Null
+SightedTransitionSeconds: 0.25
+AimDownSightTemplate: 04B246:Starfield.esm
+AimModel: 13C237:Starfield.esm
+AccuracyBonus: 5
+AmmoType: 22F508:Starfield.esm
+ProjectilesCount: 1
+WAM2Unknown1: 1
+MeleeOrCreature: {}
+PrimedExplosive: {}
+DryFire: {}
+Idle: {}
+Equip: {}
+Unequip: {}
+FastEquip: {}
+SoundLevel: Silent
+WAUDUnknown2: 3
+WTUR: 0x01000034C200003442000070C20000A0400000B4420000B4420000803F
+ChargeCritBonus: 1
+AttackDamage: 86
+MinRange: 1000
+MaxRange: 3250
+OutOfRangeDamageMult: 1
+CritDamageMult: 2
+CriticalHitSpell: 0913C4:Starfield.esm
+WDMGUnknown4: 1
+WDMGUnknown5: 1
+WDMGUnknown6: 1
+WDMGUnknown7: 1
+WDMGUnknown8: 1
+WDMGUnknown9: 1
+CritChanceIncMult: 1
+DamageTypes:
+- DamageType: 01EDE8:Starfield.esm
+  Value: 86
+RepeatableFire: True
+AttackSeconds: 1.118
+AttackDelaySeconds: 0.6666667
+DisableShellCaseEject: True
+ShotsPerSecond: 1.5
+WFIRUnknown7: 0.6666667
+OverrideRateOfFire: True
+TriggerThresholdPrimaryTrigger: 0.33
+TriggerThresholdSecondStage: 0.33
+HasStagedTrigger: True
+BurstDelaySeconds: 0.3
+NonPlayable: True
+CannotDrop: True
+WFLGUnknown4: True
+WGENUnknown1: 12
+BaseWeight: 3
+BaseSpeed: 1
+AttackOxygenCost: 250
+General: "¼\x02\0"
+WMELUnknown1: 2
+MeleeReach: 1
+MeleeStagger: Medium
+PowerRechargeTime: 0.6
+UsePower: True
+QNAMUnknown5: 1
+ReloadSpeed: 0.1
+FirstPersonModel:
+  File: ''
+  FLLD: 0x01000000
+ImpactDataSet: 13737A:Starfield.esm
+ColorRemappingIndex: 3.4028235E+38
+WTRMUnknown1: 40
+WTRMUnknown3: 0.3
+WTRMUnknown4: 0.5
+WTRMUnknown5: 55
+MajorFlags:
+- NonPlayable


### PR DESCRIPTION
Not complete, but a proof of concept.   

Still missing:
- Armor
- Cell
- Condition Form
- Misc Item
- Perk
- Quest
- Resource

Will be chugging on those.   Additionally, will be working on sprucing up some of the content, such as:
- Better defaults for Translated Strings.  `Description` field on `abRejuvenation03` doesn't need to be included, for ex
- `MajorFlags`/`StarfieldMajorRecordFlags`/`MajorRecordFlagsRaw` can be de-duped
- `SWA-EM_Ballistic_EMP-200_lvl38`'s `EmbeddedWeaponMod` can probably be omitted

Hopefully provides a glimpse into the what it can be one the other records are parsed out.   I wouldn't recommend "driving" any releases off these definitions yet, of course, as they're not complete.