### PR TITLE
Potential fix for esm releases missing content

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -71,7 +71,7 @@ jobs:
 
         - name: run spriggit
           shell: bash
-          run: .github/spriggit/Spriggit.CLI deserialize --InputPath "spriggit" --OutputPath "${{ github.workspace }}/to-pack/StarfieldCommunityPatch.esm" --PackageName Spriggit.Yaml.Starfield
+          run: .github/spriggit/Spriggit.CLI deserialize --InputPath "spriggit" --OutputPath "${{ github.workspace }}/to-pack/StarfieldCommunityPatch.esm"
           
         - name: Upload plugin and strings
           uses: actions/upload-artifact@v3

--- a/.github/workflows/nightly-publish.yml
+++ b/.github/workflows/nightly-publish.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: run spriggit
         shell: bash
-        run: .github/spriggit/Spriggit.CLI deserialize --InputPath "spriggit" --OutputPath "${{ github.workspace }}/to-pack/StarfieldCommunityPatch.esm" --PackageName Spriggit.Yaml.Starfield
+        run: .github/spriggit/Spriggit.CLI deserialize --InputPath "spriggit" --OutputPath "${{ github.workspace }}/to-pack/StarfieldCommunityPatch.esm"
         
       - name: zip
         uses: vimtor/action-zip@v1

--- a/.spriggit
+++ b/.spriggit
@@ -1,5 +1,5 @@
 {
   "PackageName": "Spriggit.Yaml",
   "Release": "Starfield",
-  "Version": "0.15"
+  "Version": "0.16"
 }

--- a/.spriggit
+++ b/.spriggit
@@ -1,5 +1,5 @@
 {
   "PackageName": "Spriggit.Yaml",
   "Release": "Starfield",
-  "Version": "0.13"
+  "Version": "0.15"
 }

--- a/spriggit/Npcs/FC_Neon_Styx.yaml
+++ b/spriggit/Npcs/FC_Neon_Styx.yaml
@@ -48,7 +48,8 @@ Properties:
   Value: 100
 - ActorValue: 0002E3:Starfield.esm
   Value: 130
-ForcedLocRefType: 261350:Starfield.esm
+ForcedLocations:
+- 261350:Starfield.esm
 Confidence: Foolhardy
 EnergyLevel: 50
 Responsibility: NoCrime

--- a/spriggit/RecordData.yaml
+++ b/spriggit/RecordData.yaml
@@ -1,6 +1,6 @@
 SpriggitSource:
   PackageName: Spriggit.Yaml.Starfield
-  Version: 0.14
+  Version: 0.16
 ModKey: StarfieldCommunityPatch.esm
 GameRelease: Starfield
 ModHeader:


### PR DESCRIPTION
Releases of the esm built from spriggit did not have all the content.

This ended up being caused by a bug within Spriggit, where if given a relative path, it would not be able to detect some subfolders (such as dialog responses) and omit them in the outgoing esm.  

I tested on my fork, and the nightly release seemed to give out a more healthily sized esm of 6117 kb (up from the 3277kb from the broken setup before)
https://github.com/Noggog/Starfield-Community-Patch/actions/runs/7519442613
https://github.com/Noggog/Starfield-Community-Patch/releases