### PR TITLE
Adjust if statements for later build steps to consider short circuit

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -125,7 +125,7 @@ jobs:
     package-mod:
       name: Package with BA2
       runs-on: windows-latest
-      if: ${{ always() }}
+      if: ${{ needs.check-changes.outputs.should_run >= 1 || (github.event_name == 'workflow_dispatch' && always()) }}
       needs: [build-plugin, compile-scripts]
       permissions: write-all
       steps: 
@@ -195,7 +195,7 @@ jobs:
     share-release:
       name: Share release
       needs: [package-mod]
-      if: ${{ inputs.publish-release == true && always() }}
+      if: ${{ inputs.publish-release == true && (needs.check-changes.outputs.should_run >= 1 || (github.event_name == 'workflow_dispatch' && always())) }}
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v4


### PR DESCRIPTION
The later steps were running even if the previous steps had short circuited.   This adds the same short circuit check so they get skipped as well.  

Not 100% sure this will work, but sometimes hard to test CI without trying it.  Tested it on my fork, but some of the build steps failed due to missing some of the download secrets