### PR TITLE
Fix for #545

### DIFF
--- a/.github/ISSUE_TEMPLATE/ReportIssue.yml
+++ b/.github/ISSUE_TEMPLATE/ReportIssue.yml
@@ -103,7 +103,7 @@ body:
         new game, the community may not be able to identify and fix it."
       options:
         - Yes, I can recreate this issue.
-        - No, I cannot recreated this issue.
+        - No, I cannot recreate this issue.
     validations:
       required: true
   - type: textarea

--- a/Scripts/Source/Fragments/Quests/qf_mq204_002c6d74.psc
+++ b/Scripts/Source/Fragments/Quests/qf_mq204_002c6d74.psc
@@ -1506,8 +1506,6 @@ Function Fragment_Stage_0610_Item_00()
     Self.SetStage(492)
   EndIf
   MQ204xPostQuest.Start()
-  CityNewAtlantisLocation.Reset()
-  CityNewAtlantisWellLocation.Reset()
   Actor NoelREF = Alias_Noel.GetActorRef()
   NoelREF.SetGhost(False)
   MQ204_NA_StateChangeHandler.SetStageNoWait(10)
@@ -1700,4 +1698,5 @@ Function Fragment_Stage_2000_Item_00()
   If COM_SQ01_SonaLeft.GetValueInt() == 1
     Alias_Sona.GetActorRef().EnableNoWait(False)
   EndIf
+  kmyQuest.MQ204EnableLayer.Delete()
 EndFunction

--- a/Scripts/Source/bescript.psc
+++ b/Scripts/Source/bescript.psc
@@ -1345,11 +1345,17 @@ Actor Function SpawnGenericActor(ObjectReference spawnPoint, bescript:genericcre
     If ShouldCrewStartInCombat && OwnerFaction == None && !isSurfaceEncounter
       newActor.SetValue(Aggression, CONST_Aggression_VeryAggressive as Float)
     EndIf
-
-    ; SFCP fix: remove any possibly erroneous crime faction the actor might be a part of.
-    ; Only use the ship's crime faction. https://www.starfieldpatch.dev/issues/323
-    newActor.SetCrimeFaction(enemyShipCrimeFaction)
-
+    ; --------------------------------------------------------------------------------------
+    ; SFCP removed If statement
+    ; Bug fix: remove any possibly erroneous crime faction the actor might be a part of.
+    ; Only use the ship's crime faction.
+    ; --------------------------------------------------------------------------------------
+    ;If enemyShipCrimeFaction != None
+      newActor.SetCrimeFaction(enemyShipCrimeFaction)
+    ;EndIf
+    ; --------------------------------------------------------------------------------------
+    ; End SFCP Edit
+    ; --------------------------------------------------------------------------------------
     ObjectReference spawnLink = spawnPoint.GetLinkedRef(None)
     If spawnLink != None
       newActor.SetLinkedRef(spawnLink, None, True)

--- a/Scripts/Source/companionaffinityeventsscript.psc
+++ b/Scripts/Source/companionaffinityeventsscript.psc
@@ -149,7 +149,7 @@ Event ObjectReference.OnItemAdded(ObjectReference akSender, Form akBaseItem, Int
   If PlayerRef.IsOverEncumbered()
     Self.SendAffinityEvent(COM_Event_Action_BecomeOverEncumbered, None, False)
   EndIf
-  Self.GotoState("")
+  Self.GotoState("None")
 EndEvent
 
 Event OnTimer(Int aiTimerID)
@@ -193,7 +193,8 @@ Event OnQuestStarted()
   Self.RegisterForRemoteEvent(PlayerRef as ScriptObject, "OnPlayerCraftItem")
   Self.RegisterForRemoteEvent(PlayerRef as ScriptObject, "OnPlayerModArmorWeapon")
   Self.RegisterForRemoteEvent(PlayerRef as ScriptObject, "OnPlayerModifiedShip")
-  Self.RegisterForMenuOpenCloseEvent("ChargenMenu") ; Formerly called for "LooksMenu", which is what ChargenMenu was called in Fallout 4 - Bobbyclue 9/21/23
+  ; LooksMenu was changed to ChargenMenu in Starfield
+  Self.RegisterForMenuOpenCloseEvent("ChargenMenu")
   Self.RegisterForRemoteEvent(PlayerRef as ScriptObject, "OnPlayerFireWeapon")
   Self.RegisterForRemoteEvent(PlayerRef as ScriptObject, "OnPlayerScannedObject")
   Self.RegisterForRemoteEvent(PlayerRef as ScriptObject, "OnSpellCast")
@@ -290,7 +291,7 @@ Event ObjectReference.OnSpellCast(ObjectReference akSender, Form akSpell)
   If akSpell.HasKeyword(Artifact_Power)
     Self.SendAffinityEvent(COM_Event_Action_UseStarbornPower, None, False)
   EndIf
-  Self.GotoState("")
+  Self.GotoState("None")
 EndEvent
 
 Event actor.OnPlayerCraftItem(Actor akSender, ObjectReference akBench, Location akLocation, Form akCreatedItem)
@@ -310,8 +311,9 @@ Event Actor.OnPlayerModifiedShip(Actor akSender, spaceshipreference akShip)
 EndEvent
 
 Event OnMenuOpenCloseEvent(String asMenuName, Bool abOpening)
-  If asMenuName == "ChargenMenu" && abOpening == False ; Formerly called for "LooksMenu", which is what ChargenMenu was called in Fallout 4 - Bobbyclue 9/21/23
-    Self.SendAffinityEvent(COM_Event_Action_Enhance_PlayerChangeAppearance, None, False, True)
+  ; LooksMenu has been changed to ChargenMenu
+  If asMenuName == "ChargenMenu" && abOpening == False
+    Self.SendAffinityEvent(COM_Event_Action_Enhance_PlayerChangeAppearance, None, False)
   EndIf
 EndEvent
 
@@ -420,13 +422,10 @@ Event Actor.OnPickLock(Actor akSender, ObjectReference akLockedRef, Bool abCrime
   EndIf
 EndEvent
 
-Function SendAffinityEvent(affinityevent EventToSend, ObjectReference targetRef, Bool ignoreCooldown, Bool ignorePlayerInDialogue = False)
-  Bool PlayerInDialogue = False
+Function SendAffinityEvent(affinityevent EventToSend, ObjectReference targetRef, Bool ignoreCooldown)
+  Bool PlayerInDialogue = Game.IsPlayerInDialogue()
   Bool CompanionInScene = False
   Actor CompanionRef = ActiveCompanion.GetActorReference()
-  If !ignorePlayerInDialogue ; Added optional bypass of dialogue check for the sake of appearance change dialogue. All appearance changes occur in dialogue, and Game.IsPlayerInDialogue() can return true even if the dialogue menu is closed - Bobbyclue 9/22/23
-    PlayerInDialogue = Game.IsPlayerInDialogue()
-  EndIf
   If CompanionRef
     CompanionInScene = CompanionRef.IsInScene()
   EndIf

--- a/spriggit/Quests/SFCP_Hotfix/RecordData.yaml
+++ b/spriggit/Quests/SFCP_Hotfix/RecordData.yaml
@@ -19,6 +19,9 @@ VirtualMachineAdapter:
     - MutagenObjectType: ScriptObjectProperty
       Name: SFCP_CND_AllResearchCompleted
       Object: 000808:StarfieldCommunityPatch.esm
+    - MutagenObjectType: ScriptObjectProperty
+      Name: MQ206A
+      Object: 2BACF9:Starfield.esm
   Script:
     Name: ''
   Aliases:


### PR DESCRIPTION
Shuts down the commitment quest for the dead companion if it is still running on stage 1000 of MQ206A (Missed Beyond Measure). In stage 2000, the vanilla MQ206A script checks to see if the commitment quest is running and if so, will make the companion the active companion but it never checks to see if that companion is the one who died in High Price to Pay.